### PR TITLE
Fix critical and warning messages about accept button

### DIFF
--- a/keysign/app.py
+++ b/keysign/app.py
@@ -27,6 +27,7 @@ gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, GLib
 gi.require_version('Gst', '1.0')
 from gi.repository import Gst
+from gi.repository import Gdk
 
 
 if  __name__ == "__main__" and __package__ is None:
@@ -159,6 +160,15 @@ class KeysignApp(Gtk.Application):
             "send_stack", "Send")
         self.send_receive_stack.add_titled(rs,
             "receive_stack", "Receive")
+
+        # These properties must be set after the stacks has been added to the window
+        # because they require a window element that "receive.ui" file doesn't provide.
+        accel_group = Gtk.AccelGroup()
+        window.add_accel_group(accel_group)
+        self.receive.accept_button.add_accelerator("clicked", accel_group, ord('o'), Gdk.ModifierType.MOD1_MASK,
+                                                   Gtk.AccelFlags.VISIBLE)
+        self.receive.accept_button.set_can_default(True)
+
         window.show_all()
         self.add_window(window)
 

--- a/keysign/receive.py
+++ b/keysign/receive.py
@@ -70,6 +70,8 @@ class ReceiveApp:
             builder.add_objects_from_file(ui_file,
                 [widget_name, 'confirm-button-image'])
 
+        self.accept_button = builder.get_object("confirm_sign_button")
+
         old_scanner = builder.get_object("scanner_widget")
         old_scanner_parent = old_scanner.get_parent()
 

--- a/keysign/receive.ui
+++ b/keysign/receive.ui
@@ -489,7 +489,6 @@ Alpha Bar &lt;example@example.com&gt;</property>
                 <property name="can_focus">True</property>
                 <property name="is_focus">True</property>
                 <property name="can_default">True</property>
-                <property name="has_default">True</property>
                 <property name="receives_default">True</property>
                 <property name="image">confirm-button-image</property>
                 <property name="use_underline">True</property>
@@ -498,7 +497,6 @@ Alpha Bar &lt;example@example.com&gt;</property>
                 <accessibility>
                   <action action_name="click" description="Confirm signing the OpenPGP Key"/>
                 </accessibility>
-                <accelerator key="o" signal="clicked" modifiers="GDK_MOD1_MASK"/>
                 <style>
                   <class name="suggested-action"/>
                 </style>


### PR DESCRIPTION
The properties `accelerator` and `has_default` cause a critical and a
warning messages because "receive.ui" file doesn't have a window element.
With this fix I moved these two properties in the code after the
connection of the window to the receive stack.